### PR TITLE
feat: improve recent colors

### DIFF
--- a/src/components/Verte.vue
+++ b/src/components/Verte.vue
@@ -139,7 +139,7 @@
           a.verte__recent-color(
             role="button"
             href="#"
-            v-for="clr in recentColorsArray"
+            v-for="clr in $_verteStore.recentColors"
             :style="`background: ${clr}`"
             @click.prevent="selectColor(clr)"
           )
@@ -147,10 +147,11 @@
 </template>
 
 <script>
+import { toRgb, toHex, toHsl, isValidColor } from 'color-fns';
 import Picker from './Picker.vue';
 import Slider from './Slider.vue';
-import { toRgb, toHex, toHsl, getRandomColor, isValidColor } from 'color-fns';
-import { newArray, isElementClosest, warn, makeListValidator, getEventCords } from '../utils';
+import { initStore } from '../store';
+import { isElementClosest, warn, makeListValidator, getEventCords } from '../utils';
 
 export default {
   name: 'Verte',
@@ -206,10 +207,13 @@ export default {
     hex: toHex('#000'),
     hsl: toHsl('#000'),
     delta: { x: 0, y: 0 },
-    currentModel: '',
-    recentColorsArray: null,
+    currentModel: ''
   }),
   computed: {
+    $_verteStore () {
+      // Should return the store singleton instance.
+      return initStore();
+    },
     currentColor: {
       get () {
         if (!this[this.model] && process.env.NODE_ENV !== 'production') {
@@ -277,7 +281,7 @@ export default {
     handleMenuDrag (event) {
       if (event.button === 2) return;
       event.preventDefault();
-  
+
       const lastMove = Object.assign({}, this.delta);
       const startPosition = getEventCords(event);
 
@@ -302,7 +306,7 @@ export default {
     },
     submit () {
       this.$emit('beforeSubmit', this.currentColor);
-      this.addRecentColor(this.currentColor);
+      this.$_verteStore.addRecentColor(this.currentColor);
       this.$emit('input', this.currentColor);
       this.$emit('submit', this.currentColor);
     },
@@ -315,20 +319,6 @@ export default {
       const normalized = Math.min(Math.max(el.value, el.min), el.max);
       this[this.currentModel][value] = normalized;
       this.selectColor(this[this.currentModel]);
-    },
-    addRecentColor (newColor) {
-      if (!this.recentColors) {
-        return;
-      }
-      const colors = this.recentColorsArray;
-      const max = 6;
-      if (colors.includes(newColor)) {
-        return;
-      }
-      if (colors.length >= max) {
-        colors.shift();
-      }
-      colors.push(newColor);
     },
     toggleMenu () {
       if (this.isMenuActive) {
@@ -355,15 +345,13 @@ export default {
       document.addEventListener('mousedown', this.closeCallback);
     }
   },
+  beforeCreate () {
+    // initialize the store early, _base is the vue constructor.
+    initStore(this.$options._base);
+  },
   created () {
     this.selectColor(this.value || '#000', true);
     this.currentModel = this.model;
-    this.recentColorsArray = (() => {
-      if (this.recentColors === true) {
-        return newArray(6, getRandomColor)
-      }
-      return this.recentColors;
-    })()
   },
   mounted () {
     // give sliders time to
@@ -419,7 +407,6 @@ $dot-space: 4px;
   &:focus
     outline: none
 
-
 .verte__menu-origin
   display: none
   position: absolute
@@ -446,7 +433,6 @@ $dot-space: 4px;
     justify-content: center
     align-items: center
     background-color: rgba($black, 0.1)
-    
 
   &:focus
     outline: none
@@ -492,7 +478,7 @@ $dot-space: 4px;
   min-width: 0
   text-align: center
   border-width: 0 0 1px 0
-  &::-webkit-inner-spin-button, 
+  &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button
     -webkit-appearance: none
     margin: 0

--- a/src/components/Verte.vue
+++ b/src/components/Verte.vue
@@ -349,6 +349,11 @@ export default {
     // initialize the store early, _base is the vue constructor.
     initStore(this.$options._base);
   },
+  // When used as a target for Vue.use
+  install (Vue, opts) {
+    initStore(Vue, opts);
+    Vue.component('Verte', this); // install self
+  },
   created () {
     this.selectColor(this.value || '#000', true);
     this.currentModel = this.model;

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,34 @@
+import { getRandomColor } from 'color-fns';
+import { newArray } from './utils';
+
+const MAX_COLOR_HISTROY = 6;
+let Vue;
+let store;
+
+export function initStore (_Vue, { recentColors } = {}) {
+  if (store) {
+    return store;
+  }
+
+  Vue = _Vue;
+  store = new Vue({
+    data: () => ({
+      recentColors: recentColors || newArray(6, getRandomColor)
+    }),
+    methods: {
+      addRecentColor (newColor) {
+        if (this.recentColors.includes(newColor)) {
+          return;
+        }
+
+        if (this.recentColors.length >= MAX_COLOR_HISTROY) {
+          this.recentColors.shift();
+        }
+
+        this.recentColors.push(newColor);
+      }
+    }
+  });
+
+  return store;
+};

--- a/src/store.js
+++ b/src/store.js
@@ -5,10 +5,13 @@ const MAX_COLOR_HISTROY = 6;
 let Vue;
 let store;
 
-export function initStore (_Vue, { recentColors } = {}) {
+export function initStore (_Vue, opts) {
   if (store) {
     return store;
   }
+
+  opts = opts || {};
+  const { recentColors, onRecentColorsChange } = opts;
 
   Vue = _Vue;
   store = new Vue({
@@ -26,6 +29,9 @@ export function initStore (_Vue, { recentColors } = {}) {
         }
 
         this.recentColors.push(newColor);
+        if (onRecentColorsChange) {
+          onRecentColorsChange(this.recentColors);
+        }
       }
     }
   });


### PR DESCRIPTION
This PR implements a Vue based store to manage shared values among verte instances, like `recentColors`.

The recent colors have been extracted to an external state, and exposed as a computed prop on the verte instance.

This PR also adds the ability to define initial recent colors to start with, instead of random colors and offers a callback for when those colors change to allow developers to persist colors to an external storage like `localStorage`.

```js
// example on a persisted recent colors using localStorage
Vue.use(Verte, {
  recentColors: JSON.parse(localStorage.getItem('colors')),
  onRecentColorsChange (colors) {
    localStorage.setItem('colors', JSON.stringify(colors));
  }
})
```

This means `Verte` can be used as a Vue plugin which will initialize the store values and install the component globally.

The only downside, that it makes initializing a different recent list for each component not possible at this moment.