### PR TITLE
feat: color-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
 
 A Complete Vue.js Color Picker Component
 
+## Features
+
+- Multiple Color Models support: RGB, HSL, and HEX.
+- SSR Friendly.
+- Small file size, only 7kb gzipped.
+- Two way binding support.
+
 ## Getting Started
 
 ### Installation

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,7 @@ const sidebars = {
   guide: [
     '',
     'getting-started',
+    'color-history',
     'binding'
   ],
   api: 'api',

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,8 @@
 |`value` | a valid color string |'#000' | the initial color value |
 |`model` | 'rgb' \| 'hex' \| 'hsl' | 'rgb' | the output color model |
 |`menuPosition` | 'top' \| 'bottom' \| 'left' \| 'right' \| 'center' | 'bottom' | the output color model |
-|`recentColors` | null \| true \| Array | true | set the current recent colors, if set to `true` it will generate random colors (default), or you can disable it by setting it `null` |
+|`showHistory` | boolean | true | show a list of the recent colors at the bottom of the picker |
+| `colorHistory` | `string[]` | `null` | a list of strings representing color values. If provided it will isolate the picker from other pickers and it will maintain its own list. |
 |`display` | String | 'vertical' | controls the layout of the component. [List of allowed values](#display-modes). |
 |`draggable` | Boolean | true | turn on/off dragging the picker menu |
 |`enableAlpha` | Boolean | true | turn on/off the alpha slider |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -121,10 +121,10 @@ Display the component vertically using a trigger button and allow dragging.
 
 Display the component vertically using a trigger button and allow dragging.
 
-<verte-demo value="#f0f" display="widget" :recentColors="null"></verte-demo>
+<verte-demo value="#f0f" display="widget" :showHistory="false"></verte-demo>
 
 ```vue
-<verte display="widget" :recentColors="null"></verte>
+<verte display="widget" :showHistory="null"></verte>
 ```
 
 <style>

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -4,6 +4,7 @@ Verte is a customizable color picker component built for Vue.js, it supports man
 
 ## Features
 
-- Multiple Color Models support: RGB, HSL, and Hex.
+- Multiple Color Models support: RGB, HSL, and HEX.
+- SSR Friendly.
 - Small file size, only 7kb gzipped.
 - Two way binding support.

--- a/docs/guide/color-history.md
+++ b/docs/guide/color-history.md
@@ -1,0 +1,48 @@
+# Color History
+
+Verte offers a couple of ways to maintain the list of recent colors picked using the picker.
+
+## Internal Store
+
+By default all Verte pickers share the same color history, which can be configured when first configuring verte.
+
+```vue
+import Vue from 'vue';
+import Verte from 'verte';
+
+Vue.use(Verte, {
+  recentColors: JSON.parse(localStorage.getItem('colors'))
+});
+```
+
+You can subscribe to the changes of the recent colors by passing an `onRecentColorsChange` handler to the config object:
+
+```vue
+// fetch and save the recent colors to the localstorage.
+Vue.use(Verte, {
+  recentColors: JSON.parse(localStorage.getItem('colors')),
+  onRecentColorsChange (colors) {
+    localStorage.setItem('colors', JSON.stringify(colors));
+  }
+});
+```
+
+## Using Props
+
+Verte accepts a `colorHistory` prop which is an array of color strings, this will disable sharing between verte components and each one will have its own history.
+
+```vue
+<Verte :showHistory="true" :colorHistory="list"></Verte>
+```
+
+You could allow sharing between some verte components using `.sync` modifier:
+
+```vue
+<Verte :showHistory="true" :colorHistory.sync="list"></Verte>
+
+<Verte :showHistory="true" :colorHistory.sync="list"></Verte>
+```
+
+::: tip
+When providing the `colorHistory` prop, the Vete store does not handle any changes to the history, also the `onRecentColorsChange` handler will no longer fire. So you might need to handle persisting the color histroy using `watch` and conventional Vue patterns.
+:::

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 import { getRandomColor } from 'color-fns';
 import { newArray } from './utils';
 
-const MAX_COLOR_HISTROY = 6;
+export const MAX_COLOR_HISTROY = 6;
 let Vue;
 let store;
 
@@ -25,10 +25,10 @@ export function initStore (_Vue, opts) {
         }
 
         if (this.recentColors.length >= MAX_COLOR_HISTROY) {
-          this.recentColors.shift();
+          this.recentColors.pop();
         }
 
-        this.recentColors.push(newColor);
+        this.recentColors.unshift(newColor);
         if (onRecentColorsChange) {
           onRecentColorsChange(this.recentColors);
         }


### PR DESCRIPTION
This PR introduces a couple of breaking changes and major enhancement to the color-history API.

### Breaking Changes

- deprecated `recentColors` prop as it tried to do way too many things.

as a replacement, two new props have been added:

- added `showHistory` prop to control the recent colors list visibility.
- added `colorHistory` prop which is used to provide a list of colors.

### New Features

#20 Disabled the ability to provide shareable colors after the app is bootstrapped, which prevents lazy components or dynamic ones from specifying the recent colors.

The new `colorHistory` prop allows the user to pass an array of color strings which will be used as the source of the history, the internal store implemented in #20 will be ignored and local data will be used to control the recent colors. This means all verte components passing `colorHistory` will be isolated and will not share the same colors.

The use of `.sync` modifier will solve this problem:

```vue
<Verte :showHistory="true" :colorHistory.sync="list"></Verte>

<Verte :showHistory="true" :colorHistory.sync="list"></Verte>
```

This allows the developer to be able to maintain and control the recent colors as they see fit.

The docs have been updated to reflect those changes.

closes #26 