### PR TITLE
docs: make code block style consistent

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -79,7 +79,7 @@ export default {
 
 <verte-demo picker="wheel"></verte-demo>
 
-```
+```vue
   <verte picker="wheel"></verte>
 ```
 


### PR DESCRIPTION
Fix code block style inconsistent

<img width="801" alt="Screen Shot 2019-05-17 at 9 42 00" src="https://user-images.githubusercontent.com/5120965/57895730-28636a00-7888-11e9-8ac1-bd0f5cab3ffb.png">
