### PR TITLE
[fix] Fix first init color pick

### DIFF
--- a/src/components/Picker.vue
+++ b/src/components/Picker.vue
@@ -247,6 +247,7 @@ export default {
           this.updateCursorPosition(getEventCords(evnt))
         });
       }
+      tempFunc(event)
       const handleRelase = () => {
         document.removeEventListener('mousemove', tempFunc);
         document.removeEventListener('touchmove', tempFunc);


### PR DESCRIPTION
**Not change value with first click**

**Describe the bug**
Widgets with a set black color (or without a set value) the first time you click in the color selection canvas, the value does not change.

It appears on examples page.

**To Reproduce**
Steps to reproduce the behavior:

1. Go to examples page in docs
2. Click on any widget with set black color (or withour a set value)
3. Click on color choose canvas
4. See is value not change

**Expected behavior**
Value is change