### PR TITLE
Updating hex text input to work with or without a hashtag

### DIFF
--- a/src/components/Verte.vue
+++ b/src/components/Verte.vue
@@ -353,6 +353,10 @@ export default {
     inputChanged (event, value) {
       const el = event.target;
       if (this.currentModel === 'hex') {
+        if (typeof el.value !== 'object' && el.value.indexOf('#') !== 0) {
+          el.value = '#' + el.value;
+        }
+
         this.selectColor(el.value);
         return;
       }


### PR DESCRIPTION
Issue #87 describes a bug that occurs when users enter a hex value without prepending a `#`.

This PR simply prepends a `#` to the hex value if it was missing, allowing the color picker to accept hex values like `#000` or `000`.